### PR TITLE
health_check: remove custom in standard check

### DIFF
--- a/lib/generators/modulorails/healthcheck/templates/config/initializers/health_check.rb.tt
+++ b/lib/generators/modulorails/healthcheck/templates/config/initializers/health_check.rb.tt
@@ -35,7 +35,7 @@ HealthCheck.setup do |config|
   # config.buckets = { 'bucket_name' => %i[R W D] }
 
   # You can customize which checks happen on a standard health check, eg to set an explicit list use:
-  config.standard_checks = %w[database migrations custom]
+  config.standard_checks = %w[database migrations]
 
   # Or to exclude one check:
   config.standard_checks -= %w[emailconf]


### PR DESCRIPTION
Remove custom check from standard healthcheck, because with sidekiq check, it will make the application unavailable when there is an issue on sidekiq side.

We have to check for all existing projects.