### PR TITLE
fix: use DATABASE_URL in ci because database.yml can only use that now

### DIFF
--- a/lib/generators/modulorails/gitlabci/templates/.gitlab-ci.yml.tt
+++ b/lib/generators/modulorails/gitlabci/templates/.gitlab-ci.yml.tt
@@ -15,7 +15,7 @@ variables:
   POSTGRES_DB: <%= @image_name %>_test
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  DATABASE_URL: postgresql://postgres:postgres@postgres/<%= @image_name %>_test
+  DATABASE_TEST_URL: postgresql://postgres:postgres@postgres/<%= @image_name %>_test
   <%- end -%>
 
 stages:

--- a/lib/generators/modulorails/gitlabci/templates/.gitlab-ci.yml.tt
+++ b/lib/generators/modulorails/gitlabci/templates/.gitlab-ci.yml.tt
@@ -10,12 +10,12 @@ variables:
   <%- if @adapter =~ /mysql/ -%>
   MYSQL_DATABASE: <%= @image_name %>_test
   MYSQL_ALLOW_EMPTY_PASSWORD: 'true'
-  <%= @environment_name %>_DATABASE_HOST: mysql
+  DATABASE_URL: mysql://root@mysql/<%= @image_name %>_test
   <%- else -%>
   POSTGRES_DB: <%= @image_name %>_test
   POSTGRES_USER: postgres
   POSTGRES_PASSWORD: postgres
-  <%= @environment_name %>_DATABASE_HOST: postgres
+  DATABASE_URL: postgresql://postgres:postgres@postgres/<%= @image_name %>_test
   <%- end -%>
 
 stages:


### PR DESCRIPTION
This MR aim to fix the issue when creating the new projet, in gitlab-ci it set up the environment variable `<%= @environment_name %>_DATABASE_HOST` which is deprecated because in `database.yml` the templating only handle `DATABASE_URL`