### PR TITLE
Increase pods memory default and remove cpu limits

### DIFF
--- a/lib/generators/modulorails/gitlabci/templates/config/deploy/production.yaml.tt
+++ b/lib/generators/modulorails/gitlabci/templates/config/deploy/production.yaml.tt
@@ -18,9 +18,9 @@ ingress:
 resources:
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 1024Mi
   limits:
-    memory: 512Mi
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
@@ -47,10 +47,10 @@ sidekiq:
 #  resources:
 #    requests:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #    limits:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #  autoscaling:
 #    enabled: true
 #    minReplicas: 1

--- a/lib/generators/modulorails/gitlabci/templates/config/deploy/review.yaml.tt
+++ b/lib/generators/modulorails/gitlabci/templates/config/deploy/review.yaml.tt
@@ -18,9 +18,9 @@ ingress:
 resources:
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 1024Mi
   limits:
-    memory: 512Mi
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
@@ -46,10 +46,10 @@ sidekiq:
 #  resources:
 #    requests:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #    limits:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #  autoscaling:
 #    enabled: true
 #    minReplicas: 1

--- a/lib/generators/modulorails/gitlabci/templates/config/deploy/staging.yaml.tt
+++ b/lib/generators/modulorails/gitlabci/templates/config/deploy/staging.yaml.tt
@@ -18,9 +18,9 @@ ingress:
 resources:
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 1024Mi
   limits:
-    memory: 512Mi
+    memory: 1024Mi
 
 autoscaling:
   enabled: true
@@ -46,10 +46,10 @@ sidekiq:
 #  resources:
 #    requests:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #    limits:
 #      cpu: 100m
-#      memory: 512Mi
+#      memory: 1024Mi
 #  autoscaling:
 #    enabled: true
 #    minReplicas: 1

--- a/lib/generators/modulorails/sidekiq/sidekiq_generator.rb
+++ b/lib/generators/modulorails/sidekiq/sidekiq_generator.rb
@@ -158,10 +158,9 @@ class Modulorails::SidekiqGenerator < Rails::Generators::Base
           resources:
             requests:
               cpu: 100m
-              memory: 512Mi
+              memory: 1024Mi
             limits:
-              cpu: 100m
-              memory: 512Mi
+              memory: 1024Mi
           autoscaling:
             enabled: true
             minReplicas: 1


### PR DESCRIPTION
This pull request increases the memory allocation for both `ingress` and `sidekiq` components across all deployment environments (production, staging, and review) in the deployment configuration templates. The change aims to provide more memory resources to these components, which can help prevent out-of-memory errors and improve application stability.

Resource allocation updates:

* Increased memory requests and limits for `ingress` from `512Mi` to `1024Mi` in `production.yaml.tt`, `staging.yaml.tt`, and `review.yaml.tt` templates. [[1]](diffhunk://#diff-0e233e538d657cd0802b771055cd93e88e3c634aa1ff1824e96eb0d6061ff68dL21-R23) [[2]](diffhunk://#diff-bb8c243d8b4803e957b540195b2ef81b3333edf2d59543d18351217aa6f9d720L21-R23) [[3]](diffhunk://#diff-e2f19738a7d7e7abe4220f9d8d3645e458bd07bb89525d707650eb4fb81c5514L21-R23)
* Increased memory requests and limits for commented-out `sidekiq` configuration from `512Mi` to `1024Mi` in `production.yaml.tt`, `staging.yaml.tt`, and `review.yaml.tt` templates. [[1]](diffhunk://#diff-0e233e538d657cd0802b771055cd93e88e3c634aa1ff1824e96eb0d6061ff68dL50-R53) [[2]](diffhunk://#diff-bb8c243d8b4803e957b540195b2ef81b3333edf2d59543d18351217aa6f9d720L49-R52) [[3]](diffhunk://#diff-e2f19738a7d7e7abe4220f9d8d3645e458bd07bb89525d707650eb4fb81c5514L49-R52)
* Updated the `sidekiq_generator.rb` to set memory requests and limits to `1024Mi` for generated `sidekiq` deployment files.